### PR TITLE
Fix/instance overload

### DIFF
--- a/experiments/hpo/binary.json
+++ b/experiments/hpo/binary.json
@@ -25,7 +25,7 @@
                 "cache": true
               }
             },
-            "agg_instances": 0
+            "agg_instances": 1
           }
         },
         "env_wrappers": [

--- a/experiments/hpo/binary_all.json
+++ b/experiments/hpo/binary_all.json
@@ -26,7 +26,7 @@
                 "target_rank": 0
               }
             },
-            "agg_instances": 0
+            "agg_instances": 1
           }
         },
         "env_wrappers": [

--- a/experiments/hpo/binary_comp.json
+++ b/experiments/hpo/binary_comp.json
@@ -25,7 +25,7 @@
                 "cache": true
               }
             },
-            "agg_instances": 0
+            "agg_instances": 1
           }
         },
         "env_wrappers": [

--- a/experiments/hpo/binary_warm.json
+++ b/experiments/hpo/binary_warm.json
@@ -25,7 +25,7 @@
                 "cache": true
               }
             },
-            "agg_instances": 0
+            "agg_instances": 1
           }
         },
         "env_wrappers": [

--- a/experiments/mmind/mmind.json
+++ b/experiments/mmind/mmind.json
@@ -34,7 +34,7 @@
             "functions": [
               0
             ],
-            "agg_instances": 0
+            "agg_instances": 1
           }
         },
         "env_wrappers": [

--- a/experiments/mmind/telltale.json
+++ b/experiments/mmind/telltale.json
@@ -31,7 +31,7 @@
                 "max_guesses": 10000
               }
             },
-            "agg_instances": 0,
+            "agg_instances": 1,
             "functions": [
               1
             ]

--- a/experiments/mmind/telltale_comp.json
+++ b/experiments/mmind/telltale_comp.json
@@ -31,7 +31,7 @@
                 "max_guesses": 10000
               }
             },
-            "agg_instances": 0,
+            "agg_instances": 1,
             "functions": [
               1
             ]

--- a/experiments/rbf/brachy.json
+++ b/experiments/rbf/brachy.json
@@ -55,7 +55,7 @@
                 "budget_multiplier": 1000
               }
             },
-            "agg_instances": 0
+            "agg_instances": 1
           }
         },
         "env_wrappers": [

--- a/jaix/suite/ec_suite.py
+++ b/jaix/suite/ec_suite.py
@@ -21,7 +21,7 @@ class ECSuiteConfig(SuiteConfig):
         self.func_classes = func_classes
         assert len(func_classes) == len(func_configs)
         functions = list(range(len(func_classes)))
-        instances = list(range(5)) if instances is None else instances
+        instances = list(range(15)) if instances is None else instances
 
         super().__init__(
             env_class=ECEnvironment,

--- a/jaix/suite/suite.py
+++ b/jaix/suite/suite.py
@@ -42,6 +42,7 @@ class SuiteConfig(Config):
         # generate instance permuations of length comp_env_num
         comp_env_num = len(self.instances) if comp_env_num is None else comp_env_num
         instance_permutations = itertools.permutations(self.instances, comp_env_num)
+        
         if agg_instances is None:
             # Nothing passed, use all permutations of instances
             if len(self.instances) > 5:
@@ -49,7 +50,7 @@ class SuiteConfig(Config):
                     "No aggregation instances passed, using all permutations of instances. "
                     "This may take a long time for large instance sets or crash the system."
                 )
-            self.agg_instances = list(instance_permutations)
+            self.agg_instances: List[Tuple[int]] = list(instance_permutations)
         elif isinstance(agg_instances, int):
             # Integer n passed, use n random permutations
             # TODO: Make this seedable
@@ -74,10 +75,9 @@ class SuiteConfig(Config):
                     )
                 )
             # expecting normal ints, so reformatting
-            self.agg_instances = [
+            self.agg_instances: List[Tuple[int]] = [
                 tuple([int(x) for x in perm]) for perm in set(inst_tuples)
             ]
-
         elif isinstance(agg_instances, list) and all(
             [isinstance(i, int) for i in agg_instances]
         ):
@@ -92,7 +92,7 @@ class SuiteConfig(Config):
                 logger.warning(
                     "Filtering out indices. This may take a long time for large instance sets"
                 )
-            self.agg_instances = []
+            self.agg_instances: List[Tuple[int]] = [] 
             for i, perm in enumerate(instance_permutations):
                 if i in agg_instances:
                     self.agg_instances.append(perm)
@@ -106,7 +106,7 @@ class SuiteConfig(Config):
                 max(i) < len(self.instances) for i in agg_instances
             ), "agg_instances must be a list of tuples with integers less than the number of instances"
             # List of tuples passed (the desired permutations). Use those directly
-            self.agg_instances = agg_instances
+            self.agg_instances: List[Tuple[int]] = agg_instances
         else:
             # Invalid type passed, raise error
             raise ValueError(

--- a/jaix/suite/suite.py
+++ b/jaix/suite/suite.py
@@ -42,7 +42,8 @@ class SuiteConfig(Config):
         # generate instance permuations of length comp_env_num
         comp_env_num = len(self.instances) if comp_env_num is None else comp_env_num
         instance_permutations = itertools.permutations(self.instances, comp_env_num)
-        
+       
+        self.agg_instances: List[Tuple[int, ...]] = []
         if agg_instances is None:
             # Nothing passed, use all permutations of instances
             if len(self.instances) > 5:
@@ -50,7 +51,7 @@ class SuiteConfig(Config):
                     "No aggregation instances passed, using all permutations of instances. "
                     "This may take a long time for large instance sets or crash the system."
                 )
-            self.agg_instances: List[Tuple[int]] = list(instance_permutations)
+            self.agg_instances: List[Tuple[int, ...]] = list(instance_permutations)
         elif isinstance(agg_instances, int):
             # Integer n passed, use n random permutations
             # TODO: Make this seedable
@@ -75,7 +76,7 @@ class SuiteConfig(Config):
                     )
                 )
             # expecting normal ints, so reformatting
-            self.agg_instances: List[Tuple[int]] = [
+            self.agg_instances: List[Tuple[int, ...]] = [
                 tuple([int(x) for x in perm]) for perm in set(inst_tuples)
             ]
         elif isinstance(agg_instances, list) and all(
@@ -92,7 +93,6 @@ class SuiteConfig(Config):
                 logger.warning(
                     "Filtering out indices. This may take a long time for large instance sets"
                 )
-            self.agg_instances: List[Tuple[int]] = [] 
             for i, perm in enumerate(instance_permutations):
                 if i in agg_instances:
                     self.agg_instances.append(perm)
@@ -106,7 +106,7 @@ class SuiteConfig(Config):
                 max(i) < len(self.instances) for i in agg_instances
             ), "agg_instances must be a list of tuples with integers less than the number of instances"
             # List of tuples passed (the desired permutations). Use those directly
-            self.agg_instances: List[Tuple[int]] = agg_instances
+            self.agg_instances: List[Tuple[int, ...]] = agg_instances
         else:
             # Invalid type passed, raise error
             raise ValueError(

--- a/jaix/suite/suite.py
+++ b/jaix/suite/suite.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional, Type, List, Union, Tuple
+from typing import Optional, Type, List, Union, Tuple, cast
 from ttex.config import ConfigurableObject, ConfigurableObjectFactory as COF, Config
 import gymnasium as gym
 import random as rnd
@@ -25,7 +25,7 @@ class SuiteConfig(Config):
         functions: Optional[List[int]] = None,
         instances: Optional[List[int]] = None,
         comp_env_num: Optional[int] = None,
-        agg_instances: Optional[Union[List[int], List[Tuple[int]], int]] = None,
+        agg_instances: Optional[Union[List[int], List[Tuple[int, ...]], int]] = None,
         seed: Optional[int] = None,
     ):
         logger.debug("Creating SuiteConfig")
@@ -81,6 +81,7 @@ class SuiteConfig(Config):
             ]
         elif isinstance(agg_instances, list):
             if all([isinstance(i, int) for i in agg_instances]):
+                agg_instances = cast(List[int], agg_instances) # otherwise mypy complains
                 assert all(
                     i >= 0 for i in agg_instances
                 ), "agg_instances must be a list of non-negative integers"
@@ -97,6 +98,7 @@ class SuiteConfig(Config):
                     if i in agg_instances:
                         self.agg_instances.append(perm)
             elif all([isinstance(i, tuple) for i in agg_instances]):
+                agg_instances = cast(List[Tuple[int, ...]], agg_instances)  # otherwise mypy complains
                 assert all(
                     min(i) >= 0 for i in agg_instances
                 ), "agg_instances must be a list of tuples with non-negative integers"

--- a/jaix/suite/suite.py
+++ b/jaix/suite/suite.py
@@ -46,6 +46,7 @@ class SuiteConfig(Config):
             self.agg_instances = [instance_permutations[i] for i in agg_instances]  # type: ignore
         else:
             self.agg_instances = agg_instances  # type: ignore
+        logger.debug(f"SuiteConfig created with {self.__dict__}")
 
 
 class Suite(ConfigurableObject):

--- a/jaix/suite/suite.py
+++ b/jaix/suite/suite.py
@@ -42,7 +42,7 @@ class SuiteConfig(Config):
         # generate instance permuations of length comp_env_num
         comp_env_num = len(self.instances) if comp_env_num is None else comp_env_num
         instance_permutations = itertools.permutations(self.instances, comp_env_num)
-       
+
         self.agg_instances: List[Tuple[int, ...]]
         if agg_instances is None:
             # Nothing passed, use all permutations of instances
@@ -81,7 +81,9 @@ class SuiteConfig(Config):
             ]
         elif isinstance(agg_instances, list):
             if all([isinstance(i, int) for i in agg_instances]):
-                agg_instances = cast(List[int], agg_instances) # otherwise mypy complains
+                agg_instances = cast(
+                    List[int], agg_instances
+                )  # otherwise mypy complains
                 assert all(
                     i >= 0 for i in agg_instances
                 ), "agg_instances must be a list of non-negative integers"
@@ -98,7 +100,9 @@ class SuiteConfig(Config):
                     if i in agg_instances:
                         self.agg_instances.append(perm)
             elif all([isinstance(i, tuple) for i in agg_instances]):
-                agg_instances = cast(List[Tuple[int, ...]], agg_instances)  # otherwise mypy complains
+                agg_instances = cast(
+                    List[Tuple[int, ...]], agg_instances
+                )  # otherwise mypy complains
                 assert all(
                     min(i) >= 0 for i in agg_instances
                 ), "agg_instances must be a list of tuples with non-negative integers"

--- a/jaix/suite/suite.py
+++ b/jaix/suite/suite.py
@@ -6,7 +6,8 @@ import random as rnd
 import logging
 from jaix import LOGGER_NAME
 import itertools
-
+import math
+import numpy as np
 
 logger = logging.getLogger(LOGGER_NAME)
 
@@ -23,8 +24,11 @@ class SuiteConfig(Config):
         env_config: Config,
         functions: Optional[List[int]] = None,
         instances: Optional[List[int]] = None,
+        comp_env_num: Optional[int] = None,
         agg_instances: Optional[Union[List[int], List[Tuple[int]], int]] = None,
+        seed: Optional[int] = None,
     ):
+        logger.debug("Creating SuiteConfig")
         self.env_class = env_class
         self.env_config = env_config
         env_info = {}
@@ -34,18 +38,62 @@ class SuiteConfig(Config):
         # and info does not exist
         self.functions = env_info["funcs"] if functions is None else functions
         self.instances = env_info["insts"] if instances is None else instances
-        instance_permutations = list(itertools.permutations(self.instances))
+        # TODO: Allow function / instance combinations
+        # generate instance permuations of length comp_env_num
+        comp_env_num = len(self.instances) if comp_env_num is None else comp_env_num
+        instance_permutations = itertools.permutations(self.instances, comp_env_num)
         if agg_instances is None:
-            self.agg_instances = instance_permutations
+            # Nothing passed, use all permutations of instances
+            if len(self.instances) > 5:
+                logger.warning(
+                    "No aggregation instances passed, using all permutations of instances. "
+                    "This may take a long time for large instance sets or crash the system."
+                )
+            self.agg_instances = list(instance_permutations)
         elif isinstance(agg_instances, int):
-            assert agg_instances < len(instance_permutations)
-            self.agg_instances = [instance_permutations[agg_instances]]
+            # Integer n passed, use n random permutations
+            # TODO: Make this seedable
+            assert agg_instances > 0, "agg_instances must be a positive integer"
+            if len(self.instances) < 5:
+                logger.warning(
+                    "Using random permutations of instances. Inefficient for small instance sets."
+                )
+            inst_tuples = [tuple(np.random.choice(self.instances, size=comp_env_num, replace=False)) for _ in range(agg_instances)]
+            while len(set(inst_tuples)) < agg_instances:
+                # Ensure we have unique tuples
+                inst_tuples.append(tuple(np.random.choice(self.instances, size=comp_env_num, replace=False)))
+            # expecting normal ints, so reformatting 
+            self.agg_instances = [tuple([int(x) for x in perm]) for perm in set(inst_tuples)]
+
         elif isinstance(agg_instances, list) and all(
             [isinstance(i, int) for i in agg_instances]
         ):
-            self.agg_instances = [instance_permutations[i] for i in agg_instances]  # type: ignore
+            assert all(i >= 0 for i in agg_instances), "agg_instances must be a list of non-negative integers"
+            assert all(i < math.factorial(len(self.instances)) for i in agg_instances), \
+                "agg_instances must be a list of integers less than the number of permutations (0 to n!)"
+            # List of integers passed (the desired indices). iterate to find the permutations
+            if len(self.instances) > 5:
+                logger.warning(
+                    "Filtering out indices. This may take a long time for large instance sets"
+                )
+            self.agg_instances = []
+            for i, perm in enumerate(instance_permutations):
+                if i in agg_instances:
+                    self.agg_instances.append(perm)
+        elif isinstance(agg_instances, list) and all(
+            [isinstance(i, tuple) for i in agg_instances]
+        ):
+            assert all(min(i) >= 0 for i in agg_instances), \
+                "agg_instances must be a list of tuples with non-negative integers"
+            assert all(max(i) < len(self.instances) for i in agg_instances), \
+                "agg_instances must be a list of tuples with integers less than the number of instances"
+            # List of tuples passed (the desired permutations). Use those directly
+            self.agg_instances = agg_instances
         else:
-            self.agg_instances = agg_instances  # type: ignore
+            # Invalid type passed, raise error
+            raise ValueError(
+                "agg_instances must be None, an integer, or a list of tuples"
+            )
         logger.debug(f"SuiteConfig created with {self.__dict__}")
 
 
@@ -68,6 +116,7 @@ class Suite(ConfigurableObject):
         logger.debug(f"Getting environments with seed {seed}")
         if agg_type != AggType.INST:
             raise NotImplementedError("Only INST aggregation is supported")
+
         for func in self.functions:
             for agg_inst in self.agg_instances:
                 envs = [self._get_env(func, inst) for inst in agg_inst]

--- a/jaix/utils/launch_experiment.py
+++ b/jaix/utils/launch_experiment.py
@@ -121,6 +121,7 @@ def run_experiment(
         )
     else:
         data_dir = None
+    logger.info(f"Running experiment with config: {exp_config}")
 
     try:
         Experiment.run(exp_config)

--- a/tests/suite/test_ec_suite.py
+++ b/tests/suite/test_ec_suite.py
@@ -32,7 +32,7 @@ def test_init(func_config, env_config):
         [func_config],
         env_config,
         instances=list(range(2)),
-        agg_instances=0,
+        agg_instances=1,
     )
     suite = COF.create(ECSuite, config)
 
@@ -46,7 +46,7 @@ def test_get_envs(func_config, env_config):
         [func_config],
         env_config,
         instances=list(range(1)),
-        agg_instances=0,
+        agg_instances=1,
     )
     suite = COF.create(ECSuite, config)
 
@@ -67,7 +67,7 @@ def test_get_envs_agg(func_config, env_config):
         [func_config],
         env_config,
         instances=list(range(3)),
-        agg_instances=0,
+        agg_instances=1,
     )
     suite = COF.create(ECSuite, config)
 

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -9,7 +9,7 @@ def init_suite():
         env_config=DummyEnvConfig(dimension=6),
         functions=[0, 1],
         instances=list(range(5)),
-        agg_instances=3,
+        agg_instances=[0, 1, 2],
     )
     return Suite(config)
 
@@ -46,9 +46,7 @@ def test_suite_config_agg_instances_many(inst, comp_env_num):
 def test_init():
     suite = init_suite()
     counter = 0
-    for agg_inst in suite.agg_instances:
-        counter +=1
-    assert counter == 3
+    assert len(suite.agg_instances) == 3
 
 
 def test_get_envs():
@@ -75,4 +73,5 @@ def test_get_agg_envs():
         assert len(envs) == len(suite.instances)
         assert isinstance(envs[0], DummyConfEnv)
         counter += 1
-    assert counter == len(suite.functions) * 3 # 3 is the number of aggregated instances in the test suite specified in the init function
+    assert counter == len(suite.functions) * len(suite.agg_instances), \
+        "Number of aggregated environments does not match expected count"

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -58,6 +58,7 @@ def test_init():
     counter = 0
     assert len(suite.agg_instances) == 3
 
+
 def test_get_envs():
     suite = init_suite()
     func = 0
@@ -82,5 +83,6 @@ def test_get_agg_envs():
         assert len(envs) == len(suite.instances)
         assert isinstance(envs[0], DummyConfEnv)
         counter += 1
-    assert counter == len(suite.functions) * len(suite.agg_instances), \
-        "Number of aggregated environments does not match expected count"
+    assert counter == len(suite.functions) * len(
+        suite.agg_instances
+    ), "Number of aggregated environments does not match expected count"

--- a/tests/suite/test_suite.py
+++ b/tests/suite/test_suite.py
@@ -1,6 +1,7 @@
 from jaix.suite import Suite, SuiteConfig, AggType
 from . import DummyEnvConfig, DummyConfEnv
-
+from collections.abc import Iterable
+import pytest
 
 def init_suite():
     config = SuiteConfig(
@@ -8,14 +9,46 @@ def init_suite():
         env_config=DummyEnvConfig(dimension=6),
         functions=[0, 1],
         instances=list(range(5)),
-        agg_instances=[0, 1, 2],
+        agg_instances=3,
     )
     return Suite(config)
+
+@pytest.mark.parametrize("inst,comp_env_num", [(20,2), (3,3)])
+def test_suite_config_agg_instances_many(inst, comp_env_num):
+    config_dict = {"env_class":DummyConfEnv,
+                       "env_config":DummyEnvConfig(dimension=6),
+                       "functions":[0, 1],
+                       "instances":list(range(inst)),
+                       "comp_env_num": comp_env_num,
+                       }
+    if inst==20:
+        agg_options = [
+            3, # 3 random permutations
+            [0, 17, 25], # specific indices
+            [(0, 1), (2, 3), (4, 5)] # specific permutations
+        ]
+    else:
+        agg_options = [
+            6, # all random permutations
+            list(range(6)), # specific indices
+            None, # all permutations
+        ]
+    for agg in agg_options:
+        config = SuiteConfig(**config_dict, agg_instances=agg)
+        assert isinstance(config.agg_instances, list), "agg_instances should be iterable"
+        assert len(config.agg_instances) == agg_options[0]
+        assert all(len(i)==comp_env_num for i in config.agg_instances), "agg_instances should contain comp_env_num instances"
+        assert all(all(isinstance(x, int) for x in i) for i in config.agg_instances), "agg_instances should contain only integers"
+        assert len(set(config.agg_instances)) == len(config.agg_instances), "agg_instances should contain unique tuples"
+
 
 
 def test_init():
     suite = init_suite()
-    assert len(suite.agg_instances) == 3
+    counter = 0
+    for agg_inst in suite.agg_instances:
+        counter +=1
+    assert counter == 3
 
 
 def test_get_envs():
@@ -42,4 +75,4 @@ def test_get_agg_envs():
         assert len(envs) == len(suite.instances)
         assert isinstance(envs[0], DummyConfEnv)
         counter += 1
-    assert counter == len(suite.functions) * len(suite.agg_instances)
+    assert counter == len(suite.functions) * 3 # 3 is the number of aggregated instances in the test suite specified in the init function

--- a/tests/test_environment_factory.py
+++ b/tests/test_environment_factory.py
@@ -38,7 +38,7 @@ def ec_config():
     )
     ec_config = ECEnvironmentConfig(budget_multiplier=1)
     config = ECSuiteConfig(
-        [Sphere], [func_config], ec_config, instances=[0], agg_instances=0
+        [Sphere], [func_config], ec_config, instances=[0], agg_instances=1
     )
     return config
 

--- a/tests/utils/test_launch_experiment.py
+++ b/tests/utils/test_launch_experiment.py
@@ -69,7 +69,7 @@ def get_config(suite="COCO", comp=False):
                             },
                         },
                         "instances": list(range(2)),
-                        "agg_instances": 0,
+                        "agg_instances": 1,
                     },
                 },
             },
@@ -90,7 +90,7 @@ def get_config(suite="COCO", comp=False):
                             },
                         },
                         "functions": [0],
-                        "agg_instances": 0,
+                        "agg_instances": 1,
                     },
                 },
             },
@@ -110,7 +110,7 @@ def get_config(suite="COCO", comp=False):
                             },
                         },
                         "instances": list(range(2)),
-                        "agg_instances": 0,
+                        "agg_instances": 1,
                     },
                 },
             },
@@ -298,7 +298,7 @@ def test_wandb_init():
     prev_mode = os.environ.get("WANDB_MODE", "online")
     os.environ["WANDB_MODE"] = "offline"
     run = wandb_init(run_config=deepcopy(get_config()), project="ci-cd")
-    assert run.mode == "dryrun"
+    assert run.settings.run_mode == "offline-run"
     shutil.rmtree(run.dir, ignore_errors=True)
     run.finish()
 
@@ -404,7 +404,7 @@ def test_launch_final(config_file):
         ]["jaix.suite.SuiteConfig"]["instances"] = [0]
         config["jaix.ExperimentConfig"]["env_config"]["jaix.EnvironmentConfig"][
             "suite_config"
-        ]["jaix.suite.SuiteConfig"]["agg_instances"] = 0
+        ]["jaix.suite.SuiteConfig"]["agg_instances"] = 1
 
     results = launch_jaix_experiment(run_config=config, wandb=False)
     exit_code = [result["exit_codes"][0] for result in results.values()][0]
@@ -412,18 +412,5 @@ def test_launch_final(config_file):
     assert data_dir is None
     assert exit_code == 0
 
-def test_launch_long():
-    config_file = "/experiments/mmind/mmind_comp.json"
-    with open(config_file, "r") as f:
-        config = json.load(f)
-    # modify the config for test (longer, logging)
-    config["jaix.ExperimentConfig"]["env_config"]["jaix.EnvironmentConfig"]["suite_config"]["jaix.suite.SuiteConfig"]["instances"] = list(range(20))
-    config["jaix.ExperimentConfig"]["env_config"]["jaix.EnvironmentConfig"]["suite_config"]["jaix.suite.SuiteConfig"]["agg_instances"] = None
-    config["jaix.ExperimentConfig"]["logging_config"]["jaix.LoggingConfig"]["log_level"] = 10
 
-    print("Running long experiment with config:", config)
-    results = launch_jaix_experiment(run_config=config, wandb=False)
-    exit_code = [result["exit_codes"][0] for result in results.values()][0]
-    data_dir = [result["data_dirs"][0] for result in results.values()][0]
-    assert data_dir is None
-    assert exit_code == 0
+

--- a/tests/utils/test_launch_experiment.py
+++ b/tests/utils/test_launch_experiment.py
@@ -411,3 +411,19 @@ def test_launch_final(config_file):
     data_dir = [result["data_dirs"][0] for result in results.values()][0]
     assert data_dir is None
     assert exit_code == 0
+
+def test_launch_long():
+    config_file = "/experiments/mmind/mmind_comp.json"
+    with open(config_file, "r") as f:
+        config = json.load(f)
+    # modify the config for test (longer, logging)
+    config["jaix.ExperimentConfig"]["env_config"]["jaix.EnvironmentConfig"]["suite_config"]["jaix.suite.SuiteConfig"]["instances"] = list(range(20))
+    config["jaix.ExperimentConfig"]["env_config"]["jaix.EnvironmentConfig"]["suite_config"]["jaix.suite.SuiteConfig"]["agg_instances"] = None
+    config["jaix.ExperimentConfig"]["logging_config"]["jaix.LoggingConfig"]["log_level"] = 10
+
+    print("Running long experiment with config:", config)
+    results = launch_jaix_experiment(run_config=config, wandb=False)
+    exit_code = [result["exit_codes"][0] for result in results.values()][0]
+    data_dir = [result["data_dirs"][0] for result in results.values()][0]
+    assert data_dir is None
+    assert exit_code == 0


### PR DESCRIPTION
This pull request introduces several changes across multiple files to enhance the configuration and functionality of the `jaix` suite and its related experiments. The key updates include modifications to the handling of `agg_instances`, improvements to the `SuiteConfig` initialization logic, and updates to test cases to align with the new functionality.

### Configuration Updates

* Updated the default value of `agg_instances` across multiple experiment configuration files (`binary.json`, `binary_all.json`, `binary_comp.json`, `binary_warm.json`, `mmind.json`, `telltale.json`, `telltale_comp.json`, `brachy.json`) from `0` to `1` to ensure proper aggregation behavior. [[1]](diffhunk://#diff-17f0c70c376440ffa44d7b332b933c2e794f0defd4b8998912cdfe7f36f2e8aaL28-R28) [[2]](diffhunk://#diff-626c996ade7d84d93998c355f490343da4f80594b22c1f1137a34c33718b4e43L29-R29) [[3]](diffhunk://#diff-33871cc04084ceaab99b546c4eafb3edfe4bb37310240c7e16a7d26b853c75e6L28-R28) [[4]](diffhunk://#diff-64c0a0587c748178dbccc7225c8e0ea59c777df28aaa1eb523e1cfbbe432b26fL28-R28) [[5]](diffhunk://#diff-ff8c7a8f08c1c538fd80da57d0d1de8587334a92fe58f4234ef821fcf81998cbL37-R37) [[6]](diffhunk://#diff-7a165c756bc11a0e684345cd7a1fcd6f90526be8dba0f671e26f446e800a48fbL34-R34) [[7]](diffhunk://#diff-70d4f9b2d41eeb0b221cf5bd4ee914c1936f0c6193f6c6985ca6909ac218ed28L34-R34) [[8]](diffhunk://#diff-b33fe61c26d26e3708dd406650abcd7f3e658181c5eeb17cb944149e6317b726L58-R58)

### Core Logic Enhancements

* Enhanced the `SuiteConfig` initialization in `jaix/suite/suite.py` to support more flexible handling of `agg_instances`, including random permutations, specific indices, and tuples of instance combinations. Added logging for better debugging and validation of input types. [[1]](diffhunk://#diff-1088ee74211d1b6a85f90122c0d8b1c24501877e0b8b3bdb1f25aadce39ef40fL26-R31) [[2]](diffhunk://#diff-1088ee74211d1b6a85f90122c0d8b1c24501877e0b8b3bdb1f25aadce39ef40fL37-R119)
* Increased the default range of `instances` in `ECEnvironment` initialization in `jaix/suite/ec_suite.py` from `5` to `15` for broader instance coverage.

### Testing Improvements

* Updated test cases across multiple files (`test_ec_suite.py`, `test_suite.py`, `test_environment_factory.py`, `test_launch_experiment.py`) to reflect the new default value of `agg_instances` and validate the updated behavior of `SuiteConfig`. Added parameterized tests to ensure robustness of `agg_instances` handling. [[1]](diffhunk://#diff-98926612ef74503421dfdebdc6638757fb5cfc717a356db9f3378a0d4dad06aaL35-R35) [[2]](diffhunk://#diff-98926612ef74503421dfdebdc6638757fb5cfc717a356db9f3378a0d4dad06aaL49-R49) [[3]](diffhunk://#diff-98926612ef74503421dfdebdc6638757fb5cfc717a356db9f3378a0d4dad06aaL70-R70) [[4]](diffhunk://#diff-25a0561c2737dcb3ec0bf0d2c9bcad8c0ca58da0c2f0fb2f7d393c40ed754240R18-R58) [[5]](diffhunk://#diff-25a0561c2737dcb3ec0bf0d2c9bcad8c0ca58da0c2f0fb2f7d393c40ed754240L45-R88) [[6]](diffhunk://#diff-285cb24e78257844b899453d8f3b7b1db97fdbe882c569624a665563ac8b06e5L41-R41) [[7]](diffhunk://#diff-1f663f19bc97fc607941e4349be0954f91353fa45e9ed1d7d674664b15921b3eL72-R72) [[8]](diffhunk://#diff-1f663f19bc97fc607941e4349be0954f91353fa45e9ed1d7d674664b15921b3eL93-R93) [[9]](diffhunk://#diff-1f663f19bc97fc607941e4349be0954f91353fa45e9ed1d7d674664b15921b3eL113-R113) [[10]](diffhunk://#diff-1f663f19bc97fc607941e4349be0954f91353fa45e9ed1d7d674664b15921b3eL407-R407)
* Fixed a test assertion in `test_wandb_init` to correctly validate the `run_mode` of the WandB configuration.

### Dependency Update

* Updated the submodule commit for `deps/tabrepo` to a new version (`4ea39e8a025c258e9b4b62849f4af461f87780d8`).

These changes collectively improve the configurability, reliability, and testing coverage of the `jaix` suite, ensuring it is better equipped to handle complex experiments.