### PR TITLE
avoid double-wrap

### DIFF
--- a/jaix/environment_factory.py
+++ b/jaix/environment_factory.py
@@ -71,12 +71,10 @@ class EnvironmentFactory:
                 agg_type=comp_config.agg_type, seed=env_config.seed
             ):
                 logger.debug(f"Got {len(envs)} from suite {suite}")
-                wrapped_envs = [WEF.wrap(env, env_config.env_wrappers) for env in envs]
-                logger.debug("Wrapped all envs")
                 comp_env = COF.create(
                     comp_config.comp_env_class,
                     comp_config.comp_env_config,
-                    wrapped_envs,
+                    envs,
                 )
                 logger.debug(f"Created composite env {comp_env}")
                 wrapped_env = WEF.wrap(comp_env, env_config.env_wrappers)
@@ -84,4 +82,3 @@ class EnvironmentFactory:
                 # TODO: reset with seeding here
                 yield wrapped_env
                 assert wrapped_env.closed
-                assert all([env.closed for env in wrapped_envs])


### PR DESCRIPTION
Avoiding wrapping sub-environments in case of composite environments. Otherwise, this will be confusing, if for example the rewards get changed